### PR TITLE
Update node installation instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,11 @@ RUN apt-get update
 RUN apt-get install -y trivy
 
 # Install node 16
-RUN curl -sL https://deb.nodesource.com/setup_16.x -o nodesource_setup.sh
-RUN chmod a+x ./nodesource_setup.sh
-RUN ./nodesource_setup.sh
-RUN apt-get install -y nodejs
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+ENV NODE_MAJOR=16
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN apt-get update
+RUN apt-get install nodejs -y
 
 # Copy files from our repository location to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Use new instructions to install node to avoid the deprecation warning [shown here](https://github.com/DataDog/shopist/actions/runs/7412374619/job/20169016710?pr=1802)