### PR TITLE
[STAL-1267] pin trivy version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN dpkg -i /tmp/trivy.deb
 RUN rm -f /tmp/trivy.dev
 
 # Install node 20
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
 RUN apt-get install -y nodejs
 
 # Copy files from our repository location to the filesystem path `/` of the container

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,8 @@ RUN curl -L -o /tmp/trivy.deb https://github.com/aquasecurity/trivy/releases/dow
 RUN dpkg -i /tmp/trivy.deb
 RUN rm -f /tmp/trivy.dev
 
-# Install node 16
-RUN curl -sL https://deb.nodesource.com/setup_16.x -o nodesource_setup.sh
-RUN chmod a+x ./nodesource_setup.sh
-RUN ./nodesource_setup.sh
+# Install node 20
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
 RUN apt-get install -y nodejs
 
 # Copy files from our repository location to the filesystem path `/` of the container

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,9 @@ FROM ubuntu:22.04
 RUN apt-get update
 RUN apt-get install -y git unzip curl
 RUN apt-get install -y wget apt-transport-https gnupg lsb-release
-RUN wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | apt-key add -
-RUN echo deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main | tee -a /etc/apt/sources.list.d/trivy.list
-RUN apt-get update
-RUN apt-get install -y trivy
+RUN curl -L -o /tmp/trivy.deb https://github.com/aquasecurity/trivy/releases/download/v0.48.3/trivy_0.48.3_Linux-64bit.deb  >/dev/null 2>&1 || exit 1
+RUN dpkg -i -f /tmp/trivy.deb
+RUN rm -f /tmp/trivy.dev
 
 # Install node 16
 RUN curl -sL https://deb.nodesource.com/setup_16.x -o nodesource_setup.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update
 RUN apt-get install -y git unzip curl
 RUN apt-get install -y wget apt-transport-https gnupg lsb-release
 RUN curl -L -o /tmp/trivy.deb https://github.com/aquasecurity/trivy/releases/download/v0.48.3/trivy_0.48.3_Linux-64bit.deb  >/dev/null 2>&1 || exit 1
-RUN dpkg -i -f /tmp/trivy.deb
+RUN dpkg -i /tmp/trivy.deb
 RUN rm -f /tmp/trivy.dev
 
 # Install node 16


### PR DESCRIPTION
## What problem are you trying to solve?

The recent upgrade of trivy (version 0.49) makes use of a new attribute of the SBOM file is being used for `npm` ecosystem. However, our system (CLI and backend) do not make use of this attribute.

The immediate solution is to revert to versoin 0.48.3 of trivy and pin the version.

## Testing

Tested in staging with our test repository [here](https://github.com/DataDog/datadog-static-analyzer-test-repo/actions/runs/7788261981/job/21237514553).


## Misc

Upgrade to node 20 using the new script. It removes a one minute delay in the GitHub action.