### PR TITLE
[STAL-1173] Support osv_scanner in the GitHub action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,8 @@ RUN rm -f /tmp/trivy.deb
 # Install OSV-Scanner from Datadog
 RUN mkdir /osv-scanner
 RUN curl -L -o /osv-scanner/osv-scanner.zip https://github.com/DataDog/osv-scanner/releases/download/v0.1.0/osv-scanner_0.1.0_linux_amd64.zip >/dev/null 2>&1 || exit 1
-RUN chmod 755 /osv-scanner/osv-scanner
 RUN (cd /osv-scanner && unzip osv-scanner.zip)
-
+RUN chmod 755 /osv-scanner/osv-scanner
 
 # Install node 20
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash -

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,13 @@ RUN curl -L -o /tmp/trivy.deb https://github.com/aquasecurity/trivy/releases/dow
 RUN dpkg -i /tmp/trivy.deb
 RUN rm -f /tmp/trivy.deb
 
+# Install OSV-Scanner from Datadog
+RUN mkdir /osv-scanner
+RUN curl -L -o /osv-scanner/osv-scanner.zip https://github.com/DataDog/osv-scanner/releases/download/v0.1.0/osv-scanner_0.1.0_linux_amd64.zip >/dev/null 2>&1 || exit 1
+RUN chmod 755 /osv-scanner/osv-scanner
+RUN (cd /osv-scanner && unzip osv-scanner.zip)
+
+
 # Install node 20
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
 RUN apt-get install -y nodejs

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: "The Datadog site. For example, users in the EU may want to set datadoghq.eu."
     required: false
     default: "datadoghq.com"
+  use_osv_scanner:
+    description: "Use Datadog osv-scanner to produce an SBOM"
+    required: false
+    default: "false"
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -31,3 +35,4 @@ runs:
     DD_SERVICE: ${{ inputs.dd_service }}
     DD_ENV: ${{ inputs.dd_env }}
     DD_SITE: ${{ inputs.dd_site }}
+    USE_OSV_SCANNER: ${{ inputs.use_osv_scanner }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -88,7 +88,7 @@ if [ ! -d "$OUTPUT_DIRECTORY" ]; then
     exit 1
 fi
 
-OUTPUT_FILE="$OUTPUT_DIRECTORY/trivy.json"
+OUTPUT_FILE="$OUTPUT_DIRECTORY/sbom.json"
 
 echo "Done: will output results at $OUTPUT_FILE"
 
@@ -101,6 +101,7 @@ cd ${GITHUB_WORKSPACE} || exit 1
 git config --global --add safe.directory ${GITHUB_WORKSPACE} || exit 1
 
 if [ "$USE_OSV_SCANNER" = "true" ]; then
+   echo "Generating SBOM with osv-scanner"
     /osv-scanner/osv-scanner --skip-git -r --experimental-only-packages --format=cyclonedx-1-4 --output="$OUTPUT_FILE" . || exit 1
 else
    echo "Generating SBOM with trivy"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -100,7 +100,7 @@ echo "Done: will output results at $OUTPUT_FILE"
 cd ${GITHUB_WORKSPACE} || exit 1
 git config --global --add safe.directory ${GITHUB_WORKSPACE} || exit 1
 
-if [ "$USE_OSV_SCANNER" == "true" ]; then
+if [ "$USE_OSV_SCANNER" = "true" ]; then
     /osv-scanner/osv-scanner --skip-git -r --experimental-only-packages --format=cyclonedx-1-4 --output="$OUTPUT_FILE" .
 else
    echo "Generating SBOM with trivy"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -101,10 +101,10 @@ cd ${GITHUB_WORKSPACE} || exit 1
 git config --global --add safe.directory ${GITHUB_WORKSPACE} || exit 1
 
 if [ "$USE_OSV_SCANNER" = "true" ]; then
-    /osv-scanner/osv-scanner --skip-git -r --experimental-only-packages --format=cyclonedx-1-4 --output="$OUTPUT_FILE" .
+    /osv-scanner/osv-scanner --skip-git -r --experimental-only-packages --format=cyclonedx-1-4 --output="$OUTPUT_FILE" . || exit 1
 else
    echo "Generating SBOM with trivy"
-   trivy fs --output "$OUTPUT_FILE" --format cyclonedx .
+   trivy fs --output "$OUTPUT_FILE" --format cyclonedx . || exit 1
 fi
 echo "Done"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -100,9 +100,14 @@ echo "Done: will output results at $OUTPUT_FILE"
 cd ${GITHUB_WORKSPACE} || exit 1
 git config --global --add safe.directory ${GITHUB_WORKSPACE} || exit 1
 
-echo "Generating SBOM"
-trivy fs --output "$OUTPUT_FILE" --format cyclonedx .
+if [ "$USE_OSV_SCANNER" == "true" ]; then
+    /osv-scanner/osv-scanner --skip-git -r --experimental-only-packages --format=cyclonedx-1-4 --output="$OUTPUT_FILE" .
+else
+   echo "Generating SBOM with trivy"
+   trivy fs --output "$OUTPUT_FILE" --format cyclonedx .
+fi
 echo "Done"
+
 
 echo "Uploading results to Datadog"
 DD_BETA_COMMANDS_ENABLED=1 ${DATADOG_CLI_PATH} sbom upload --service "$DD_SERVICE" --env "$DD_ENV" "$OUTPUT_FILE" || exit 1


### PR DESCRIPTION
## What problem are you trying to solve?

We want to start using [osv-scanner from Datadog](https://github.com/DataDog/osv-scanner) to scan dependency.

## Solution

1. Add a parameter `use_osv_scanner` to the GitHub action
2. If the parameter is set to `true`, use `osv-scanner` to extract the SBOM

For now, this is `false` by default.


## Testing

Tested both with `osv-scanner` and `trivy` [here](https://github.com/DataDog/datadog-static-analyzer-test-repo/actions/runs/7850944909).