### PR TITLE
[STAL-1741] use osv-scanner by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN rm -f /tmp/trivy.deb
 
 # Install OSV-Scanner from Datadog
 RUN mkdir /osv-scanner
-RUN curl -L -o /osv-scanner/osv-scanner.zip https://github.com/DataDog/osv-scanner/releases/download/v0.1.0/osv-scanner_0.1.0_linux_amd64.zip >/dev/null 2>&1 || exit 1
+RUN curl -L -o /osv-scanner/osv-scanner.zip https://github.com/DataDog/osv-scanner/releases/download/0.4.1/osv-scanner_linux_amd64.zip >/dev/null 2>&1 || exit 1
 RUN (cd /osv-scanner && unzip osv-scanner.zip)
 RUN chmod 755 /osv-scanner/osv-scanner
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN rm -f /tmp/trivy.deb
 
 # Install OSV-Scanner from Datadog
 RUN mkdir /osv-scanner
-RUN curl -L -o /osv-scanner/osv-scanner.zip https://github.com/DataDog/osv-scanner/releases/download/0.4.1/osv-scanner_linux_amd64.zip >/dev/null 2>&1 || exit 1
+RUN curl -L -o /osv-scanner/osv-scanner.zip https://github.com/DataDog/osv-scanner/releases/download/v0.4.1/osv-scanner_linux_amd64.zip >/dev/null 2>&1 || exit 1
 RUN (cd /osv-scanner && unzip osv-scanner.zip)
 RUN chmod 755 /osv-scanner/osv-scanner
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ The GitHub Action works for the following languages and following files:
 
  - JavaScript/TypeScript: `package-lock.json` and `yarn.lock`
  - Python: `requirements.txt` (with version defined) and `poetry.lock`
+ - Java: `pom.xml`
+ - C#
+ - Ruby
+ - ... and more languages (listed in the [documentation](https://docs.datadoghq.com/code_analysis/software_composition_analysis/))
 
 ## Setup
 

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
   use_osv_scanner:
     description: "Use Datadog osv-scanner to produce an SBOM"
     required: false
-    default: "false"
+    default: "true"
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -102,7 +102,7 @@ git config --global --add safe.directory ${GITHUB_WORKSPACE} || exit 1
 
 if [ "$USE_OSV_SCANNER" = "true" ]; then
    echo "Generating SBOM with osv-scanner"
-    /osv-scanner/osv-scanner --skip-git -r --experimental-only-packages --format=cyclonedx-1-4 --output="$OUTPUT_FILE" . || exit 1
+    /osv-scanner/osv-scanner --skip-git -r --experimental-only-packages --format=cyclonedx-1-5 --paths-relative-to-scan-dir --output="$OUTPUT_FILE" . || exit 1
 else
    echo "Generating SBOM with trivy"
    trivy fs --output "$OUTPUT_FILE" --format cyclonedx . || exit 1


### PR DESCRIPTION
## What problem are you trying to solve?

Use `osv-scanner` by default

## Solution

1. Use the latest version of `osv-scanner` (see [release](https://github.com/DataDog/osv-scanner/releases))
2. Make sure `osv-scanner` is enabled by default

## Testing

See this [pull request](https://github.com/DataDog/datadog-static-analyzer-test-repo/pull/64)

 - run with [trivy](https://github.com/DataDog/datadog-static-analyzer-test-repo/actions/runs/8636708600/job/23677367270)
 - run with [osv-scanner](https://github.com/DataDog/datadog-static-analyzer-test-repo/actions/runs/8636708600/job/23677367884)