### PR TITLE
[STAL] Update `osv-scanner` to v0.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN rm -f /tmp/trivy.deb
 
 # Install OSV-Scanner from Datadog
 RUN mkdir /osv-scanner
-RUN curl -L -o /osv-scanner/osv-scanner.zip https://github.com/DataDog/osv-scanner/releases/download/v0.4.2/osv-scanner_linux_amd64.zip >/dev/null 2>&1 || exit 1
+RUN curl -L -o /osv-scanner/osv-scanner.zip https://github.com/DataDog/osv-scanner/releases/download/v0.5.1/osv-scanner_linux_amd64.zip >/dev/null 2>&1 || exit 1
 RUN (cd /osv-scanner && unzip osv-scanner.zip)
 RUN chmod 755 /osv-scanner/osv-scanner
 


### PR DESCRIPTION
Bump `osv-scanner` to [v0.5.1](https://github.com/DataDog/osv-scanner/releases/tag/v0.5.1) to start to consume locations for vulnerabiliies (only Golang so far)