### PR TITLE
[STAL] Bump `osv-scanner` to `v0.6.2`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN rm -f /tmp/trivy.deb
 
 # Install OSV-Scanner from Datadog
 RUN mkdir /osv-scanner
-RUN curl -L -o /osv-scanner/osv-scanner.zip https://github.com/DataDog/osv-scanner/releases/download/v0.6.1/osv-scanner_linux_amd64.zip >/dev/null 2>&1 || exit 1
+RUN curl -L -o /osv-scanner/osv-scanner.zip https://github.com/DataDog/osv-scanner/releases/download/v0.6.2/osv-scanner_linux_amd64.zip >/dev/null 2>&1 || exit 1
 RUN (cd /osv-scanner && unzip osv-scanner.zip)
 RUN chmod 755 /osv-scanner/osv-scanner
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN rm -f /tmp/trivy.deb
 
 # Install OSV-Scanner from Datadog
 RUN mkdir /osv-scanner
-RUN curl -L -o /osv-scanner/osv-scanner.zip https://github.com/DataDog/osv-scanner/releases/download/v0.5.1/osv-scanner_linux_amd64.zip >/dev/null 2>&1 || exit 1
+RUN curl -L -o /osv-scanner/osv-scanner.zip https://github.com/DataDog/osv-scanner/releases/download/v0.6.1/osv-scanner_linux_amd64.zip >/dev/null 2>&1 || exit 1
 RUN (cd /osv-scanner && unzip osv-scanner.zip)
 RUN chmod 755 /osv-scanner/osv-scanner
 


### PR DESCRIPTION
Upgrading `osv-scanner` to [`v0.6.2`](https://github.com/DataDog/osv-scanner/releases/tag/v0.6.2).

This new version includes:
- reports empty version instead of reporting `0.0.0`
- fixes some bugs around PNPM and some case when linking js lockfiles to package.json
- matches the Pipenv lockfile dependencies to its source file
- matches gradle lockfile dependencies to its source file