### PR TITLE
[STAL] Update `osv-scanner` to `0.6.3`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN rm -f /tmp/trivy.deb
 
 # Install OSV-Scanner from Datadog
 RUN mkdir /osv-scanner
-RUN curl -L -o /osv-scanner/osv-scanner.zip https://github.com/DataDog/osv-scanner/releases/download/v0.5.1/osv-scanner_linux_amd64.zip >/dev/null 2>&1 || exit 1
+RUN curl -L -o /osv-scanner/osv-scanner.zip https://github.com/DataDog/osv-scanner/releases/download/v0.6.3/osv-scanner_linux_amd64.zip >/dev/null 2>&1 || exit 1
 RUN (cd /osv-scanner && unzip osv-scanner.zip)
 RUN chmod 755 /osv-scanner/osv-scanner
 


### PR DESCRIPTION
This bumps `osv-scanner` to [0.6.3](https://github.com/DataDog/osv-scanner/releases/tag/v0.6.3).

This reintroduces the minor version bump from https://github.com/DataDog/datadog-sca-github-action/pull/19 after a fix patched the issue that caused us to temporary rollback https://github.com/DataDog/datadog-sca-github-action/pull/21