### PR TITLE
Use osv-scanner by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:22.04
 
 RUN apt-get update
-RUN apt-get install curl
+RUN apt-get install -y curl
 
 # Install node 20
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash -

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,10 @@
 # Ubuntu container image to run our static analyzer
 FROM ubuntu:22.04
 
-# Install dependencies
-RUN apt-get update
-RUN apt-get install -y git unzip curl
-RUN apt-get install -y wget apt-transport-https gnupg lsb-release
-RUN curl -L -o /tmp/trivy.deb https://github.com/aquasecurity/trivy/releases/download/v0.48.3/trivy_0.48.3_Linux-64bit.deb  >/dev/null 2>&1 || exit 1
-RUN dpkg -i /tmp/trivy.deb
-RUN rm -f /tmp/trivy.deb
 
 # Install OSV-Scanner from Datadog
 RUN mkdir /osv-scanner
-RUN curl -L -o /osv-scanner/osv-scanner.zip https://github.com/DataDog/osv-scanner/releases/download/v0.6.3/osv-scanner_linux_amd64.zip >/dev/null 2>&1 || exit 1
+RUN curl -L -o /osv-scanner/osv-scanner.zip https://github.com/DataDog/osv-scanner/releases/download/v0.7.1/osv-scanner_linux_$(uname -m).zip >/dev/null 2>&1 || exit 1
 RUN (cd /osv-scanner && unzip osv-scanner.zip)
 RUN chmod 755 /osv-scanner/osv-scanner
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:22.04
 
 RUN apt-get update
-RUN apt-get install -y curl
+RUN apt-get install -y curl unzip
 
 # Install node 20
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash -

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,6 @@
 # Ubuntu container image to run our static analyzer
 FROM ubuntu:22.04
 
-
-# Install OSV-Scanner from Datadog
-RUN mkdir /osv-scanner
-RUN curl -L -o /osv-scanner/osv-scanner.zip https://github.com/DataDog/osv-scanner/releases/download/v0.7.1/osv-scanner_linux_$(uname -m).zip >/dev/null 2>&1 || exit 1
-RUN (cd /osv-scanner && unzip osv-scanner.zip)
-RUN chmod 755 /osv-scanner/osv-scanner
-
 # Install node 20
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
 RUN apt-get install -y nodejs

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:22.04
 
 RUN apt-get update
-RUN apt-get install -y curl unzip
+RUN apt-get install -y curl unzip git
 
 # Install node 20
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash -

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # Ubuntu container image to run our static analyzer
 FROM ubuntu:22.04
 
+RUN apt-get update
+RUN apt-get install curl
+
 # Install node 20
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
 RUN apt-get install -y nodejs

--- a/action.yml
+++ b/action.yml
@@ -25,10 +25,6 @@ inputs:
     description: "The Datadog site. For example, users in the EU may want to set datadoghq.eu."
     required: false
     default: "datadoghq.com"
-  use_osv_scanner:
-    description: "Use Datadog osv-scanner to produce an SBOM"
-    required: false
-    default: "true"
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,11 +26,12 @@ fi
 ########################################################
 # osv-scanner
 ########################################################
-echo "Installing osv-scanner"
 mkdir /osv-scanner
-if [ "$(uname -m)" == "aarch64"]; then
+if [ "$(uname -m)" == "aarch64" ]; then
+  echo "Installing osv-scanner for ARM64"
   curl -L -o "/osv-scanner/osv-scanner.zip" "https://github.com/DataDog/osv-scanner/releases/download/v0.7.1/osv-scanner_linux_arm64.zip" >/dev/null 2>&1 || exit 1
 else
+  echo "Installing osv-scanner for AMD64"
   curl -L -o "/osv-scanner/osv-scanner.zip" "https://github.com/DataDog/osv-scanner/releases/download/v0.7.1/osv-scanner_linux_amd64.zip" >/dev/null 2>&1 || exit 1
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,8 +26,9 @@ fi
 ########################################################
 # osv-scanner
 ########################################################
+echo "Installing osv-scanner"
 mkdir /osv-scanner
-curl -L -o /osv-scanner/osv-scanner.zip https://github.com/DataDog/osv-scanner/releases/download/v0.7.1/osv-scanner_linux_$(uname -m).zip >/dev/null 2>&1 || exit 1
+curl -L -o "/osv-scanner/osv-scanner.zip" "https://github.com/DataDog/osv-scanner/releases/download/v0.7.1/osv-scanner_linux_$(uname -m).zip" >/dev/null 2>&1 || exit 1
 (cd /osv-scanner && unzip osv-scanner.zip)
 chmod 755 /osv-scanner/osv-scanner
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,6 +23,13 @@ if [ -z "$DD_SERVICE" ]; then
     exit 1
 fi
 
+########################################################
+# osv-scanner
+########################################################
+mkdir /osv-scanner
+curl -L -o /osv-scanner/osv-scanner.zip https://github.com/DataDog/osv-scanner/releases/download/v0.7.1/osv-scanner_linux_$(uname -m).zip >/dev/null 2>&1 || exit 1
+(cd /osv-scanner && unzip osv-scanner.zip)
+chmod 755 /osv-scanner/osv-scanner
 
 ########################################################
 # datadog-ci stuff
@@ -40,6 +47,7 @@ fi
 
 echo "Done: datadog-ci available $DATADOG_CLI_PATH"
 echo "Version: $($DATADOG_CLI_PATH version)"
+
 
 ########################################################
 # output directory

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,16 +65,12 @@ echo "Done: will output results at $OUTPUT_FILE"
 cd ${GITHUB_WORKSPACE} || exit 1
 git config --global --add safe.directory ${GITHUB_WORKSPACE} || exit 1
 
-if [ "$USE_OSV_SCANNER" = "true" ]; then
-   echo "Generating SBOM with osv-scanner"
-    /osv-scanner/osv-scanner --skip-git -r --experimental-only-packages --format=cyclonedx-1-5 --paths-relative-to-scan-dir --output="$OUTPUT_FILE" . || exit 1
-else
-   echo "Generating SBOM with trivy"
-   trivy fs --output "$OUTPUT_FILE" --format cyclonedx . || exit 1
-fi
+
+echo "Generating SBOM with osv-scanner"
+/osv-scanner/osv-scanner --skip-git -r --experimental-only-packages --format=cyclonedx-1-5 --paths-relative-to-scan-dir --output="$OUTPUT_FILE" . || exit 1
 echo "Done"
 
 
 echo "Uploading results to Datadog"
-DD_BETA_COMMANDS_ENABLED=1 ${DATADOG_CLI_PATH} sbom upload --service "$DD_SERVICE" --env "$DD_ENV" "$OUTPUT_FILE" || exit 1
+${DATADOG_CLI_PATH} sbom upload --service "$DD_SERVICE" --env "$DD_ENV" "$OUTPUT_FILE" || exit 1
 echo "Done"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,7 +28,7 @@ fi
 ########################################################
 echo "Installing osv-scanner"
 mkdir /osv-scanner
-if [ "$(uname -m)" == "aarch64"];
+if [ "$(uname -m)" == "aarch64"]; then
   curl -L -o "/osv-scanner/osv-scanner.zip" "https://github.com/DataDog/osv-scanner/releases/download/v0.7.1/osv-scanner_linux_arm64.zip" >/dev/null 2>&1 || exit 1
 else
   curl -L -o "/osv-scanner/osv-scanner.zip" "https://github.com/DataDog/osv-scanner/releases/download/v0.7.1/osv-scanner_linux_amd64.zip" >/dev/null 2>&1 || exit 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,7 +28,12 @@ fi
 ########################################################
 echo "Installing osv-scanner"
 mkdir /osv-scanner
-curl -L -o "/osv-scanner/osv-scanner.zip" "https://github.com/DataDog/osv-scanner/releases/download/v0.7.1/osv-scanner_linux_$(uname -m).zip" >/dev/null 2>&1 || exit 1
+if [ "$(uname -m)" == "aarch64"];
+  curl -L -o "/osv-scanner/osv-scanner.zip" "https://github.com/DataDog/osv-scanner/releases/download/v0.7.1/osv-scanner_linux_arm64.zip" >/dev/null 2>&1 || exit 1
+else
+  curl -L -o "/osv-scanner/osv-scanner.zip" "https://github.com/DataDog/osv-scanner/releases/download/v0.7.1/osv-scanner_linux_amd64.zip" >/dev/null 2>&1 || exit 1
+fi
+
 (cd /osv-scanner && unzip osv-scanner.zip)
 chmod 755 /osv-scanner/osv-scanner
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,7 +27,7 @@ fi
 # osv-scanner
 ########################################################
 mkdir /osv-scanner
-if [ "$(uname -m)" == "aarch64" ]; then
+if [ "$(uname -m)" = "aarch64" ]; then
   echo "Installing osv-scanner for ARM64"
   curl -L -o "/osv-scanner/osv-scanner.zip" "https://github.com/DataDog/osv-scanner/releases/download/v0.7.1/osv-scanner_linux_arm64.zip" >/dev/null 2>&1 || exit 1
 else


### PR DESCRIPTION
## What problem are you trying to solve?

We need to use `osv-scanner` by default and handle ARM64 platforms.

## Solutions

1. Download osv-scanner for the correct architecture
2. Remove the option to use trivy
3. Bump the version


## Testing

See https://github.com/DataDog/datadog-static-analyzer-test-repo/actions/runs/10783609653/job/29906667908