### PR TITLE
[STAL-3099] Remove env and service

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ jobs:
       with:
         dd_api_key: ${{ secrets.DD_API_KEY }}
         dd_app_key: ${{ secrets.DD_APP_KEY }}
-        dd_service: my-app
-        dd_env: ci
         dd_site: "datadoghq.com"
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -13,14 +13,6 @@ inputs:
     description: "Your Datadog Application key used to authenticate requests."
     required: true
     default: ""
-  dd_service:
-    description: "The service you want your results tagged with."
-    required: true
-    default: ""
-  dd_env:
-    description: "The environment you want your results tagged with."
-    required: false
-    default: "none"
   dd_site:
     description: "The Datadog site. For example, users in the EU may want to set datadoghq.eu."
     required: false
@@ -31,7 +23,4 @@ runs:
   env:
     DD_API_KEY: ${{ inputs.dd_api_key }}
     DD_APP_KEY: ${{ inputs.dd_app_key }}
-    DD_SERVICE: ${{ inputs.dd_service }}
-    DD_ENV: ${{ inputs.dd_env }}
     DD_SITE: ${{ inputs.dd_site }}
-    USE_OSV_SCANNER: ${{ inputs.use_osv_scanner }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,16 +13,6 @@ if [ -z "$DD_APP_KEY" ]; then
     exit 1
 fi
 
-if [ -z "$DD_ENV" ]; then
-    echo "DD_ENV not set. Please set this variable and try again."
-    exit 1
-fi
-
-if [ -z "$DD_SERVICE" ]; then
-    echo "DD_SERVICE not set. Please set this variable and try again."
-    exit 1
-fi
-
 ########################################################
 # osv-scanner
 ########################################################
@@ -73,7 +63,7 @@ OUTPUT_FILE="$OUTPUT_DIRECTORY/sbom.json"
 echo "Done: will output results at $OUTPUT_FILE"
 
 ########################################################
-# execute trivy and upload the results
+# execute osv-scanner and upload the results
 ########################################################
 
 # navigate to workspace root, so the datadog-ci command can access the git info
@@ -87,5 +77,5 @@ echo "Done"
 
 
 echo "Uploading results to Datadog"
-${DATADOG_CLI_PATH} sbom upload --service "$DD_SERVICE" --env "$DD_ENV" "$OUTPUT_FILE" || exit 1
+${DATADOG_CLI_PATH} sbom upload --service osv-scanner --env ci "$OUTPUT_FILE" || exit 1
 echo "Done"


### PR DESCRIPTION
## What problem are you trying to solve?

We want to remove `env` and `service` from the Github actions.

## Solution

Remove them and hardcode the service to `osv-scanner` and environment to `ci`.

## Testing

 - Use this updated PR in our [test repo](https://github.com/DataDog/datadog-static-analyzer-test-repo/pull/227)
 - GitHub action works [here](https://github.com/DataDog/datadog-static-analyzer-test-repo/actions/runs/11645705751/job/32429029769?pr=227) 