### PR TITLE
Add reachability option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: "The Datadog site. For example, users in the EU may want to set datadoghq.eu."
     required: false
     default: "datadoghq.com"
+  reachability:
+    description: "Enable reachability scanning. Defaults to true."
+    required: false
+    default: "true"
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -24,3 +28,4 @@ runs:
     DD_API_KEY: ${{ inputs.dd_api_key }}
     DD_APP_KEY: ${{ inputs.dd_app_key }}
     DD_SITE: ${{ inputs.dd_site }}
+    REACHABILITY: ${{ inputs.reachability }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,12 @@ if [ -z "$DD_APP_KEY" ]; then
     exit 1
 fi
 
+if [ "$REACHABILITY" = "true" ]; then
+	REACHABILITY_ARG="--reachability"
+else
+	REACHABILITY_ARG=""
+fi
+
 ########################################################
 # datadog-sbom-generator
 ########################################################
@@ -72,7 +78,7 @@ git config --global --add safe.directory ${GITHUB_WORKSPACE} || exit 1
 
 
 echo "Generating SBOM with datadog-sbom-generator"
-/datadog-sbom-generator/datadog-sbom-generator scan --verbosity info --output="$OUTPUT_FILE" . || exit 1
+/datadog-sbom-generator/datadog-sbom-generator scan --verbosity info $REACHABILITY_ARG --output="$OUTPUT_FILE" . || exit 1
 echo "Done"
 
 


### PR DESCRIPTION
This adds an option to control whether the `datadog-sbom-generator` in run with reachability scanning enabled.