### PR TITLE
Remove Docs Team as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 * @DataDog/k9-vm-sca
 
 # Documentation
-*README.md @Datadog/documentation @DataDog/k9-vm-sca
+*README.md @DataDog/k9-vm-sca


### PR DESCRIPTION
Removes Docs as CODEOWNERS from the repo. As part of a project to reduce courtesy reviews, the Docs Team is limiting CODEOWNERS entries to repos that single-source content into the docs site or where our review is critical. We’re still happy to review content if you reach out to us directly.