### PR TITLE
[K9VULN-12982] Pass --source github-action to datadog-ci sbom upload

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,18 +2,16 @@
 
 ## How to release?
 
-In the `main` branch:
+For the full release process (including validation steps), refer to the internal Confluence page: [Release process — datadog-sca-github-action](https://datadoghq.atlassian.net/wiki/spaces/Vulnerabil/pages/6528631938).
 
-1. Create a new tag using `vX.Y.Z` version.
-```
-git tag vX.Y.Z
-git push --tags
-```
-2. Create a new release and mark it as `Latest release` in GitHub.
-3. Replace the tag pointing to the major version using to the same commit than the `vX.Y.Z` tag.
+Summary:
+
+1. Open a PR against `main` and validate your branch before merging.
+2. After merging, create a new GitHub Release from the UI: create a new `vX.Y.Z` tag and mark it as `Latest release`.
+3. (Optional) Move the major version tag to the same commit. This is only needed if users pin to `@vX` instead of `@vX.Y.Z`:
 ```
 git tag --delete vX
-git push --delete vX
-git tag vX 
+git push --delete origin vX
+git tag vX
 git push --tags
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,7 +37,7 @@ chmod 755 /datadog-sbom-generator/datadog-sbom-generator
 ########################################################
 # datadog-ci stuff
 ########################################################
-DATADOG_CI_VERSION="5.11.0"
+DATADOG_CI_VERSION="5.12.1"
 DATADOG_CLI_PATH="/usr/local/bin/datadog-ci"
 DATADOG_CI_RELEASE_BASE="https://github.com/DataDog/datadog-ci/releases/download/v${DATADOG_CI_VERSION}"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -83,5 +83,5 @@ echo "Done"
 
 
 echo "Uploading results to Datadog"
-${DATADOG_CLI_PATH} sbom upload --service datadog-sbom-generator --env ci "$OUTPUT_FILE" || exit 1
+${DATADOG_CLI_PATH} sbom upload --source github-action --service datadog-sbom-generator --env ci "$OUTPUT_FILE" || exit 1
 echo "Done"


### PR DESCRIPTION
## 🚀 Motivation 
The API needs to differentiate uploads coming from the GitHub Action vs direct CLI usage. Without a source identifier, all uploads look the same, making it impossible to track adoption metrics per integration type (e.g. `scan_source:github-action` in the `sca_pipeline_started` metric).

## 📝 Summary
- Added `--source github-action` flag to the `datadog-ci sbom upload` call in `entrypoint.sh`, so uploads from this action are tagged accordingly.
- Pinned `datadog-ci` to `5.12.1`, which includes support for the `--source` flag.
- Updated `CONTRIBUTING.md` to point to the internal Confluence release process page instead of maintaining inline steps.

## 🚧 Staging validation
- [x] Deployed and monitored using Datadog dashboards.
- [x] Proof that it works as expected, including profiling or UX screenshots.

Ran [succeeded](https://github.com/DataDog/software-composition-analysis-test/actions/runs/24197742840) and upload worked 
<img width="1198" height="403" alt="Screenshot 2026-04-09 at 16 20 22" src="https://github.com/user-attachments/assets/d3e8c0b3-5fbe-4eb6-9b2d-4c5d7c6f0b56" />

## 🆘 Recovery
Notes for on-call - **select only one**:
- [x] The change can be rolled back.
- [ ] Do not roll back. Why?: