### PR TITLE
Pin datadog-ci to verified binary with checksum

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,18 +39,18 @@ chmod 755 /datadog-sbom-generator/datadog-sbom-generator
 ########################################################
 DATADOG_CI_VERSION="5.11.0"
 DATADOG_CI_PATH="/usr/local/bin/datadog-ci"
+DATADOG_CI_RELEASE_BASE="https://github.com/DataDog/datadog-ci/releases/download/v${DATADOG_CI_VERSION}"
 
 echo "Installing 'datadog-ci' v${DATADOG_CI_VERSION}"
 if [ "$(uname -m)" = "aarch64" ]; then
   DATADOG_CI_BINARY="datadog-ci_linux-arm64"
-  DATADOG_CI_CHECKSUM="fab804583d79f0c5e042f73b3f90fd05336fe409a23ab0bab5219122db13232f"
 else
   DATADOG_CI_BINARY="datadog-ci_linux-x64"
-  DATADOG_CI_CHECKSUM="f0c002799cb72f6b372c144a753642c99d33e00021054691e865b8076fa624fb"
 fi
 
-curl -L -o "$DATADOG_CI_PATH" "https://github.com/DataDog/datadog-ci/releases/download/v${DATADOG_CI_VERSION}/${DATADOG_CI_BINARY}" || exit 1
-echo "${DATADOG_CI_CHECKSUM}  ${DATADOG_CI_PATH}" | sha256sum -c - || { echo "datadog-ci checksum verification failed"; exit 1; }
+curl -L -o "$DATADOG_CI_PATH" "${DATADOG_CI_RELEASE_BASE}/${DATADOG_CI_BINARY}" || exit 1
+curl -L -o /tmp/datadog-ci-checksums.txt "${DATADOG_CI_RELEASE_BASE}/checksums.txt" || exit 1
+grep "${DATADOG_CI_BINARY}" /tmp/datadog-ci-checksums.txt | sed "s|${DATADOG_CI_BINARY}|${DATADOG_CI_PATH}|" | sha256sum -c - || { echo "datadog-ci checksum verification failed"; exit 1; }
 chmod 755 "$DATADOG_CI_PATH"
 
 # Check that datadog-ci was installed

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,7 +38,7 @@ chmod 755 /datadog-sbom-generator/datadog-sbom-generator
 # datadog-ci stuff
 ########################################################
 DATADOG_CI_VERSION="5.11.0"
-DATADOG_CI_PATH="/usr/local/bin/datadog-ci"
+DATADOG_CLI_PATH="/usr/local/bin/datadog-ci"
 DATADOG_CI_RELEASE_BASE="https://github.com/DataDog/datadog-ci/releases/download/v${DATADOG_CI_VERSION}"
 
 echo "Installing 'datadog-ci' v${DATADOG_CI_VERSION}"
@@ -48,19 +48,19 @@ else
   DATADOG_CI_BINARY="datadog-ci_linux-x64"
 fi
 
-curl -L -o "$DATADOG_CI_PATH" "${DATADOG_CI_RELEASE_BASE}/${DATADOG_CI_BINARY}" || exit 1
+curl -L -o "$DATADOG_CLI_PATH" "${DATADOG_CI_RELEASE_BASE}/${DATADOG_CI_BINARY}" || exit 1
 curl -L -o /tmp/datadog-ci-checksums.txt "${DATADOG_CI_RELEASE_BASE}/checksums.txt" || exit 1
-grep "${DATADOG_CI_BINARY}" /tmp/datadog-ci-checksums.txt | sed "s|${DATADOG_CI_BINARY}|${DATADOG_CI_PATH}|" | sha256sum -c - || { echo "datadog-ci checksum verification failed"; exit 1; }
-chmod 755 "$DATADOG_CI_PATH"
+grep "${DATADOG_CI_BINARY}" /tmp/datadog-ci-checksums.txt | sed "s|${DATADOG_CI_BINARY}|${DATADOG_CLI_PATH}|" | sha256sum -c - || { echo "datadog-ci checksum verification failed"; exit 1; }
+chmod 755 "$DATADOG_CLI_PATH"
 
 # Check that datadog-ci was installed
-if [ ! -x "$DATADOG_CI_PATH" ]; then
-    echo "The datadog-ci was not installed correctly, not found in $DATADOG_CI_PATH."
+if [ ! -x "$DATADOG_CLI_PATH" ]; then
+    echo "The datadog-ci was not installed correctly, not found in $DATADOG_CLI_PATH."
     exit 1
 fi
 
-echo "Done: datadog-ci available $DATADOG_CI_PATH"
-echo "Version: $($DATADOG_CI_PATH version)"
+echo "Done: datadog-ci available $DATADOG_CLI_PATH"
+echo "Version: $($DATADOG_CLI_PATH version)"
 
 
 ########################################################

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,8 +48,8 @@ else
   DATADOG_CI_BINARY="datadog-ci_linux-x64"
 fi
 
-curl -L -o "$DATADOG_CLI_PATH" "${DATADOG_CI_RELEASE_BASE}/${DATADOG_CI_BINARY}" || exit 1
-curl -L -o /tmp/datadog-ci-checksums.txt "${DATADOG_CI_RELEASE_BASE}/checksums.txt" || exit 1
+curl -fL -o "$DATADOG_CLI_PATH" "${DATADOG_CI_RELEASE_BASE}/${DATADOG_CI_BINARY}" || exit 1
+curl -fL -o /tmp/datadog-ci-checksums.txt "${DATADOG_CI_RELEASE_BASE}/checksums.txt" || exit 1
 grep "${DATADOG_CI_BINARY}" /tmp/datadog-ci-checksums.txt | sed "s|${DATADOG_CI_BINARY}|${DATADOG_CLI_PATH}|" | sha256sum -c - || { echo "datadog-ci checksum verification failed"; exit 1; }
 chmod 755 "$DATADOG_CLI_PATH"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,19 +37,30 @@ chmod 755 /datadog-sbom-generator/datadog-sbom-generator
 ########################################################
 # datadog-ci stuff
 ########################################################
-echo "Installing 'datadog-ci'"
-npm install -g @datadog/datadog-ci || exit 1
+DATADOG_CI_VERSION="5.11.0"
+DATADOG_CI_PATH="/usr/local/bin/datadog-ci"
 
-DATADOG_CLI_PATH=/usr/bin/datadog-ci
+echo "Installing 'datadog-ci' v${DATADOG_CI_VERSION}"
+if [ "$(uname -m)" = "aarch64" ]; then
+  DATADOG_CI_BINARY="datadog-ci_linux-arm64"
+  DATADOG_CI_CHECKSUM="fab804583d79f0c5e042f73b3f90fd05336fe409a23ab0bab5219122db13232f"
+else
+  DATADOG_CI_BINARY="datadog-ci_linux-x64"
+  DATADOG_CI_CHECKSUM="f0c002799cb72f6b372c144a753642c99d33e00021054691e865b8076fa624fb"
+fi
+
+curl -L -o "$DATADOG_CI_PATH" "https://github.com/DataDog/datadog-ci/releases/download/v${DATADOG_CI_VERSION}/${DATADOG_CI_BINARY}" || exit 1
+echo "${DATADOG_CI_CHECKSUM}  ${DATADOG_CI_PATH}" | sha256sum -c - || { echo "datadog-ci checksum verification failed"; exit 1; }
+chmod 755 "$DATADOG_CI_PATH"
 
 # Check that datadog-ci was installed
-if [ ! -x $DATADOG_CLI_PATH ]; then
-    echo "The datadog-ci was not installed correctly, not found in $DATADOG_CLI_PATH."
+if [ ! -x "$DATADOG_CI_PATH" ]; then
+    echo "The datadog-ci was not installed correctly, not found in $DATADOG_CI_PATH."
     exit 1
 fi
 
-echo "Done: datadog-ci available $DATADOG_CLI_PATH"
-echo "Version: $($DATADOG_CLI_PATH version)"
+echo "Done: datadog-ci available $DATADOG_CI_PATH"
+echo "Version: $($DATADOG_CI_PATH version)"
 
 
 ########################################################


### PR DESCRIPTION
## 🚀 Motivation 
Previously, `datadog-ci` was installed via `npm install -g`, which fetches transitive dependencies at their latest unpinned versions — a supply chain attack surface. This pins installation to a specific release binary with SHA256 checksum verification.


## 📝 Summary
Replaced `npm install -g @datadog/datadog-ci` with a direct download of the pre-built binary from the official GitHub release (`v5.11.0`). The script now:
- Downloads the architecture-appropriate binary (ARM64 or AMD64) from `DataDog/datadog-ci` releases
- Verifies the SHA256 checksum against the hardcoded value sourced from the official `checksums.txt`
- Aborts if verification fails

This eliminates transitive npm dependencies entirely, following the same pattern already used for `datadog-sbom-generator`.

## Tests
✅ Tested locally for checksum verification:

<img width="1498" height="54" alt="image" src="https://github.com/user-attachments/assets/8707f50b-9a22-458e-93aa-70abbe4dcd6d" />

