### PR TITLE
[K9VULN-12784] Add `exit_on_config_failure` input to github action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: "Enable reachability scanning. Defaults to true."
     required: false
     default: "true"
+  exit_on_config_failure:
+    description: "Stop scanning if fetching merged configuration fails. Defaults to false."
+    required: false
+    default: "false"
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -29,3 +33,4 @@ runs:
     DD_APP_KEY: ${{ inputs.dd_app_key }}
     DD_SITE: ${{ inputs.dd_site }}
     REACHABILITY: ${{ inputs.reachability }}
+    EXIT_ON_CONFIG_FAILURE: ${{ inputs.exit_on_config_failure }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,6 +19,12 @@ else
 	REACHABILITY_ARG=""
 fi
 
+if [ "$EXIT_ON_CONFIG_FAILURE" = "true" ]; then
+	EXIT_ON_CONFIG_FAILURE_ARG="--exit-on-config-failure"
+else
+	EXIT_ON_CONFIG_FAILURE_ARG=""
+fi
+
 ########################################################
 # datadog-sbom-generator
 ########################################################
@@ -89,7 +95,7 @@ git config --global --add safe.directory ${GITHUB_WORKSPACE} || exit 1
 
 
 echo "Generating SBOM with datadog-sbom-generator"
-/datadog-sbom-generator/datadog-sbom-generator scan --verbosity info $REACHABILITY_ARG --output="$OUTPUT_FILE" . || exit 1
+/datadog-sbom-generator/datadog-sbom-generator scan --verbosity info $REACHABILITY_ARG $EXIT_ON_CONFIG_FAILURE_ARG --output="$OUTPUT_FILE" . || exit 1
 echo "Done"
 
 


### PR DESCRIPTION
## Summary
- Adds `exit_on_config_failure` input to `action.yml` (default: `false`) to let users control the associated sbom-generator [flag](https://github.com/DataDog/datadog-sbom-generator/blob/main/USAGE.md#flags)
- Maps to `EXIT_ON_CONFIG_FAILURE` env var in `entrypoint.sh`, passing `--exit-on-config-failure` to `datadog-sbom-generator scan` when enabled

## Testing
- Used GH action based on this branch to verify action succeeded (run [here](https://github.com/DataDog/software-composition-analysis-test/actions/runs/24510595301))

