### PR TITLE
[NOJIRA] Update sbom-generator to v1.11.0 and add manifest_parsers input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: "Stop scanning if fetching merged configuration fails. Defaults to false."
     required: false
     default: "false"
+  manifest_parsers:
+    description: "Also run parsers that extract packages from manifest files (e.g. pyproject.toml) when no lock file is present. Defaults to false."
+    required: false
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -101,7 +105,7 @@ runs:
     - name: Install datadog-sbom-generator
       shell: bash
       run: |
-        SBOMGEN_VERSION="1.10.0"
+        SBOMGEN_VERSION="1.11.0"
         tmpdir="$(mktemp -d)"
         SBOMGEN_FILENAME="datadog-sbom-generator_${SBOMGEN_OS}_${SBOMGEN_ARCH}.zip"
         SBOMGEN_RELEASE_BASE="https://github.com/DataDog/datadog-sbom-generator/releases/download/v${SBOMGEN_VERSION}"
@@ -202,6 +206,7 @@ runs:
         DD_SITE: ${{ inputs.dd_site }}
         REACHABILITY: ${{ inputs.reachability }}
         EXIT_ON_CONFIG_FAILURE: ${{ inputs.exit_on_config_failure }}
+        MANIFEST_PARSERS: ${{ inputs.manifest_parsers }}
       run: |
         if [ "$TEST_SKIP_SCAN_UPLOAD" = "true" ]; then
           echo "Skipping SBOM generation and upload after successful tool installation"
@@ -216,6 +221,10 @@ runs:
 
         if [ "$EXIT_ON_CONFIG_FAILURE" = "true" ]; then
           scan_args+=(--exit-on-config-failure)
+        fi
+
+        if [ "$MANIFEST_PARSERS" = "true" ]; then
+          scan_args+=(--manifest-parsers)
         fi
 
         OUTPUT_FILE="$(mktemp /tmp/sbom.XXXXXX.json)"


### PR DESCRIPTION
## Summary
- Bump datadog-sbom-generator from 1.10.0 to 1.11.0
- Add opt-in `manifest_parsers` input (default `false`) that wires through to `--manifest-parsers`, enabling manifest-file extractors (e.g. pyproject.toml) when no lock file is present

## Test plan
- Created updates to test workflow to allow input flag and added a repo with a pyproject.toml file [here](https://github.com/DataDog/software-composition-analysis-test/pull/84)
     - Ran [workflow](https://github.com/DataDog/software-composition-analysis-test/actions/runs/25324499878) without flag set, verified zero deps for test 
     - Ran [workflow](https://github.com/DataDog/software-composition-analysis-test/actions/runs/25324807287/job/74242724699) with flag set, verified deps showed up for test repo
<img width="1243" height="530" alt="Screenshot 2026-05-04 at 10 29 46 AM" src="https://github.com/user-attachments/assets/c3cb2b2b-8902-4cfe-a487-c08da58960e6" />
<img width="1783" height="443" alt="Screenshot 2026-05-04 at 10 30 52 AM" src="https://github.com/user-attachments/assets/5826e82c-bcb5-44aa-ad26-971a1c124cb4" />

