### PR TITLE
Bump datadog-sbom-generator to v1.11.3

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -105,7 +105,7 @@ runs:
     - name: Install datadog-sbom-generator
       shell: bash
       run: |
-        SBOMGEN_VERSION="1.11.0"
+        SBOMGEN_VERSION="1.11.3"
         tmpdir="$(mktemp -d)"
         SBOMGEN_FILENAME="datadog-sbom-generator_${SBOMGEN_OS}_${SBOMGEN_ARCH}.zip"
         SBOMGEN_RELEASE_BASE="https://github.com/DataDog/datadog-sbom-generator/releases/download/v${SBOMGEN_VERSION}"


### PR DESCRIPTION
## 🚀 Motivation 
Bump `datadog-sbom-generator` to v1.11.3 to pick up two bug fixes and parser improvements from the [v1.11.3 release](https://github.com/DataDog/datadog-sbom-generator/releases/tag/v1.11.3): a fix for the `===` operator in `requirements.txt` parsing and a new Swift Package Manager parser.

## 📝 Summary
Updated `SBOMGEN_VERSION` in `action.yml` from `1.11.0` to `1.11.3`.

v1.11.3 release includes:
- Fix `requirements.txt` parser mishandling the `===` (PEP 440 arbitrary equality) operator ([#143](https://github.com/DataDog/datadog-sbom-generator/pull/143))
- Add Swift Package Manager parser for `Package.swift`/`Package.resolved` ([#139](https://github.com/DataDog/datadog-sbom-generator/pull/139))