### PR TITLE
[K9VULN-14992] Use install-datadog-ci-github-action for datadog-ci install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
+.vscode/
 *~

--- a/action.yml
+++ b/action.yml
@@ -54,32 +54,28 @@ runs:
         fi
 
         case "$RUNNER_ARCH" in
-          X64)   SBOMGEN_ARCH="amd64" ; DDCI_ARCH="x64"   ;;
-          ARM64) SBOMGEN_ARCH="arm64" ; DDCI_ARCH="arm64"  ;;
+          X64)   SBOMGEN_ARCH="amd64" ;;
+          ARM64) SBOMGEN_ARCH="arm64" ;;
           *)
             echo "::error title=Unsupported architecture::this action does not support $RUNNER_ARCH"
             exit 1
             ;;
         esac
         echo "SBOMGEN_ARCH=$SBOMGEN_ARCH" >> "$GITHUB_ENV"
-        echo "DDCI_ARCH=$DDCI_ARCH" >> "$GITHUB_ENV"
 
         case "$RUNNER_OS" in
           Linux)
             SBOMGEN_OS="linux"
-            DDCI_OS="linux"
             ;;
           macOS)
             SBOMGEN_OS="darwin"
-            DDCI_OS="darwin"
             ;;
           Windows)
-            if [ "$DDCI_ARCH" != "x64" ]; then
+            if [ "$RUNNER_ARCH" != "X64" ]; then
               echo "::error title=Unsupported platform::this action does not support $RUNNER_OS/$RUNNER_ARCH"
               exit 1
             fi
             SBOMGEN_OS="windows"
-            DDCI_OS="win"
             ;;
           *)
             echo "::error title=Unsupported platform::this action does not support $RUNNER_OS/$RUNNER_ARCH"
@@ -87,7 +83,6 @@ runs:
             ;;
         esac
         echo "SBOMGEN_OS=$SBOMGEN_OS" >> "$GITHUB_ENV"
-        echo "DDCI_OS=$DDCI_OS" >> "$GITHUB_ENV"
 
         DATADOG_SCA_ROOT="$(mktemp -d)"
         DATADOG_SCA_BIN_DIR="$DATADOG_SCA_ROOT/bin"
@@ -155,48 +150,9 @@ runs:
         echo "Done: datadog-sbom-generator installed"
 
     - name: Install datadog-ci
-      shell: bash
-      run: |
-        DATADOG_CI_VERSION="5.12.1"
-        DATADOG_CI_BINARY="datadog-ci_${DDCI_OS}-${DDCI_ARCH}"
-        DATADOG_CI_RELEASE_BASE="https://github.com/DataDog/datadog-ci/releases/download/v${DATADOG_CI_VERSION}"
-        tmpdir="$(mktemp -d)"
-        DDCI_PATH="$DATADOG_SCA_BIN_DIR/datadog-ci"
-        if [ "$DDCI_OS" = "win" ]; then
-          DDCI_PATH="$DDCI_PATH.exe"
-        fi
-
-        echo "Installing 'datadog-ci' v${DATADOG_CI_VERSION}"
-        curl $CURL_ARGS \
-          -o "$DDCI_PATH" "${DATADOG_CI_RELEASE_BASE}/${DATADOG_CI_BINARY}" || exit 1
-        curl $CURL_ARGS \
-          -o "$tmpdir/datadog-ci-checksums.txt" "${DATADOG_CI_RELEASE_BASE}/checksums.txt" || exit 1
-
-        expected_checksum="$(awk -v filename="$DATADOG_CI_BINARY" 'index($0, filename) {print $1; exit}' "$tmpdir/datadog-ci-checksums.txt")"
-        if [ -z "$expected_checksum" ]; then
-          echo "::error title=Checksum verification failed::checksum for $DATADOG_CI_BINARY was not found"
-          exit 1
-        fi
-
-        if command -v sha256sum >/dev/null 2>&1; then
-          actual_checksum="$(sha256sum "$DDCI_PATH" | awk '{print $1}')"
-        elif command -v shasum >/dev/null 2>&1; then
-          actual_checksum="$(shasum -a 256 "$DDCI_PATH" | awk '{print $1}')"
-        elif command -v openssl >/dev/null 2>&1; then
-          actual_checksum="$(openssl dgst -sha256 "$DDCI_PATH" | awk '{print $NF}')"
-        else
-          echo "::error title=Checksum verification failed::no supported SHA256 tool found"
-          exit 1
-        fi
-
-        if [ "$actual_checksum" != "$expected_checksum" ]; then
-          echo "::error title=Checksum verification failed::datadog-ci checksum verification failed"
-          exit 1
-        fi
-
-        chmod +x "$DDCI_PATH"
-        echo "DDCI_PATH=$DDCI_PATH" >> "$GITHUB_ENV"
-        echo "Done: datadog-ci $("$DDCI_PATH" version)"
+      uses: DataDog/install-datadog-ci-github-action@6d7f0c7c5402a4b1912055b76970ca76bef71fe5 # v1.0.4
+      with:
+        version: v5.12.1
 
     - name: Generate and upload SBOM
       shell: bash
@@ -237,5 +193,5 @@ runs:
         echo "Done"
 
         echo "Uploading results to Datadog"
-        "$DDCI_PATH" sbom upload --source github-action --service datadog-sbom-generator --env ci "$OUTPUT_FILE" || exit 1
+        datadog-ci sbom upload --source github-action --service datadog-sbom-generator --env ci "$OUTPUT_FILE" || exit 1
         echo "Done"


### PR DESCRIPTION
## 🚀 Motivation
Per the datadog-ci team's feedback, this action's bespoke `datadog-ci` installer (curl + checksum + chmod, ~43 lines) duplicates work that the official `DataDog/install-datadog-ci-github-action` already handles. Adopting it reduces maintenance cost, lets future upstream `datadog-ci` fixes reach users automatically, and closes GitHub issue #49.

## 📝 Summary
- Replaced the "Install datadog-ci" step in `action.yml` with `uses: DataDog/install-datadog-ci-github-action@6d7f0c7c5402a4b1912055b76970ca76bef71fe5 # v1.0.4`, pinning `version: v5.12.1` to match current behavior.

## 🚧 Staging validation
- [x] Tested [here](https://github.com/DataDog/software-composition-analysis-test/actions/runs/26041779406), [here](https://github.com/DataDog/software-composition-analysis-test/actions/runs/26041790116) and [here](https://github.com/DataDog/software-composition-analysis-test/actions/runs/26041804001)
 
## 🆘 Recovery
Notes for on-call - **select only one**:
- [x] The change can be rolled back.
- [ ] Do not roll back. Why?:
