### PR TITLE
Create release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release new version
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+" # e.g. v4.3.0 (excludes major aliases like v4 to not duplicate releases)
+
+permissions: {}
+
+jobs:
+  tests:
+    name: Run platform tests
+    uses: ./.github/workflows/test-platforms.yml
+
+  draft-release:
+    name: Create draft GitHub release
+    needs: tests # only create a release if tests pass
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # to create the release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          gh release create "$TAG" \
+            --draft \
+            --title "$TAG" \
+            --generate-notes

--- a/.github/workflows/test-platforms.yml
+++ b/.github/workflows/test-platforms.yml
@@ -2,7 +2,10 @@ name: Test Platforms
 
 on:
   push:
+    branches:
+      - "**"
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   test-platforms:


### PR DESCRIPTION
## 🚀 Motivation 
Releases for this GitHub Action were created manually, which is error-prone and inconsistent. We need an automated workflow to create releases when a new version tag is pushed.

## 📝 Summary
Added a new `release.yml` workflow that triggers on semver version tags (e.g. `v4.3.0`, excluding major aliases). It first runs the existing platform tests and, only if they pass, creates a draft GitHub release with auto-generated release notes.

The `test-platforms.yml` workflow was also updated to:
- Run on all branch pushes (previously had no branch filter)
- Support `workflow_call` so it can be reused by the release workflow