### PR TITLE
[NOJIRA] Bump datadog-sbom-generator to v1.13.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -100,7 +100,7 @@ runs:
     - name: Install datadog-sbom-generator
       shell: bash
       run: |
-        SBOMGEN_VERSION="1.11.3"
+        SBOMGEN_VERSION="1.13.1"
         tmpdir="$(mktemp -d)"
         SBOMGEN_FILENAME="datadog-sbom-generator_${SBOMGEN_OS}_${SBOMGEN_ARCH}.zip"
         SBOMGEN_RELEASE_BASE="https://github.com/DataDog/datadog-sbom-generator/releases/download/v${SBOMGEN_VERSION}"


### PR DESCRIPTION
## 🚀 Motivation
Update the GitHub Action to stay in sync with the latest stable `datadog-sbom-generator` release so users pick up upstream parser additions and bug fixes (e.g. lockfile-less JS package.json extractor, MANIFEST.MF fallback parser for JARs, Bun lockfile parser).

## 📝 Summary
- Bumps `SBOMGEN_VERSION` in `action.yml` from `1.11.3` to `1.13.1` - see [release details](https://github.com/DataDog/datadog-sbom-generator/releases/tag/v1.13.1)

## 🧪 Testing
- Tested on [ubuntu](https://github.com/DataDog/software-composition-analysis-test/actions/runs/26165256148), [macos](https://github.com/DataDog/software-composition-analysis-test/actions/runs/26165278606), and [windows](https://github.com/DataDog/software-composition-analysis-test/actions/runs/26165290709) CI runners to verify action worked successfully 

## 🆘 Recovery
Notes for on-call - **select only one**:
- [x] The change can be rolled back.
- [ ] Do not roll back. Why?: