### PR TITLE
[NOJIRA] Update sbom-generator to v1.14.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -100,7 +100,7 @@ runs:
     - name: Install datadog-sbom-generator
       shell: bash
       run: |
-        SBOMGEN_VERSION="1.13.1"
+        SBOMGEN_VERSION="1.14.0"
         tmpdir="$(mktemp -d)"
         SBOMGEN_FILENAME="datadog-sbom-generator_${SBOMGEN_OS}_${SBOMGEN_ARCH}.zip"
         SBOMGEN_RELEASE_BASE="https://github.com/DataDog/datadog-sbom-generator/releases/download/v${SBOMGEN_VERSION}"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"0a5eafa8-2c80-472e-9f08-4e5ca6125543","source":"chat","resourceId":"8d8ebc0a-4a14-4b57-a99c-3450223ab3ba","workflowId":"b6015bee-4af3-4284-a8cc-c1c5f4b2ae47","codeChangeId":"b6015bee-4af3-4284-a8cc-c1c5f4b2ae47","sourceType":"slack"} -->
## Summary

Updates the `datadog-sbom-generator` dependency from v1.13.1 to v1.14.0.

## Changes

Updated `SBOMGEN_VERSION` in `action.yml` from `1.13.1` to `1.14.0`

## Testing

Ran test workflow on [ubuntu](https://github.com/DataDog/software-composition-analysis-test/actions/runs/26470485978), [windows](https://github.com/DataDog/software-composition-analysis-test/actions/runs/26470519652), and [macos](https://github.com/DataDog/software-composition-analysis-test/actions/runs/26470505112) runners
